### PR TITLE
Added display_time function implementation and utils.h header

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,14 @@
+#include "utils.h"
+#include "globals.h"
+#include <curses.h>
+#include <time.h>
+#include <unistd.h> // For usleep function
+
+void display_time(WINDOW *win, int height, int width) {
+  time_t rawtime;
+  struct tm *timeinfo;
+  char buffer[9];
+  time(&rawtime);
+  timeinfo = localtime(&rawtime);
+  strftime(buffer, sizeof(buffer), "%H:%M", timeinfo);
+  

--- a/src/utils.c
+++ b/src/utils.c
@@ -11,4 +11,12 @@ void display_time(WINDOW *win, int height, int width) {
   time(&rawtime);
   timeinfo = localtime(&rawtime);
   strftime(buffer, sizeof(buffer), "%H:%M", timeinfo);
-  
+
+  // Display the time next to the vertical bar with red color
+  wattron(win, COLOR_PAIR(5)); // Red color for the time
+  mvwprintw(win, height + 2 + OFFSET_Y, width - 13, "TIME: %s",
+            buffer); // Time moved down closer to bottom-right
+  wattroff(win, COLOR_PAIR(5));
+
+  wrefresh(win); // Refresh window to show the updated time
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,8 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <curses.h>
+
+void display_time(WINDOW *win, int height, int width);
+
+#endif // UTILS_H


### PR DESCRIPTION
The code introduces the implementation of the display_time function, which uses the ncurses library to display the current time in red next to a vertical bar. The function retrieves the system's local time, formats it into "HH
", and prints it near the bottom-right corner of the window. The header file utils.h was also added to declare the display_time function, ensuring it can be used across different parts of the project.